### PR TITLE
Fix harmless typo to test subject regexp directly vs. using matchAddress

### DIFF
--- a/Condition.ts
+++ b/Condition.ts
@@ -117,9 +117,6 @@ class Condition {
                 }
                 return false;
             }
-            case ConditionType.SUBJECT: {
-                return this.regexp.test(message_data.subject);
-            }
             case ConditionType.FROM: {
                 return this.matchAddress(message_data.from);
             }
@@ -140,6 +137,9 @@ class Condition {
             }
             case ConditionType.RECEIVER: {
                 return this.matchAddress(...message_data.receivers);
+            }
+            case ConditionType.SUBJECT: {
+                return this.regexp.test(message_data.subject);
             }
             case ConditionType.BODY: {
                 return this.regexp.test(message_data.body);


### PR DESCRIPTION
Really trivial fix, and after looking it over I believe the behavior is 100% equivalent the way the code was written, but it looked suspicious while I was troubleshooting a problem with rule matching.

Sending as a PR just to sanity check.