### PR TITLE
Get tests passing by avoiding V8 runtime, etc.

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -2,6 +2,5 @@
   "timeZone": "America/Los_Angeles",
   "dependencies": {
   },
-  "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8"
+  "exceptionLogging": "STACKDRIVER"
 }

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,56 @@
+// Polyfills
+
+// String.startsWith polyfill
+if (!String.prototype.startsWith) {
+    Object.defineProperty(String.prototype, 'startsWith', {
+        value: function(search, rawPos) {
+            var pos = rawPos > 0 ? rawPos|0 : 0;
+            return this.substring(pos, pos + search.length) === search;
+        }
+    });
+}
+
+// String.endsWith polyfill
+if (!String.prototype.endsWith) {
+    String.prototype.endsWith = function(search, this_len) {
+        if (this_len === undefined || this_len > this.length) {
+            this_len = this.length;
+        }
+        return this.substring(this_len - search.length, this_len) === search;
+    };
+}
+
+// Object.assign polyfill
+if (typeof Object.assign !== 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target === null || target === undefined) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource !== null && nextSource !== undefined) {
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}
+
 // Top level functions
 
 // Triggered when Spreadsheet is opened


### PR DESCRIPTION
Changes runtimeVersion, adds polyfills, and adds missing stub methods
in base_message test object to get tests passing.

This fixes the errors, but please advise on style and what to do with `runtimeVersion` for now.

Helps with #5.