### PR TITLE
Add missing stubs in base_message test object to fix errors in tests

### DIFF
--- a/Condition.ts
+++ b/Condition.ts
@@ -198,12 +198,14 @@ class Condition {
         t('/some-.*@gmail.com/', 'some2-mailing-list@gmail.com', true, false);
 
         const base_message = {
-            getFrom: () => "",
-            getTo: () => "",
+            getFrom: () => '',
+            getTo: () => '',
             getCc: () => '',
             getBcc: () => '',
+            getReplyTo: () => '',
             getSubject: () => '',
             getPlainBody: () => '',
+            getRawContent: () => '',
         } as GoogleAppsScript.Gmail.GmailMessage;
 
         function c(condition_str: string, message: Partial<GoogleAppsScript.Gmail.GmailMessage>, expected: boolean) {


### PR DESCRIPTION
Missing `getReplyTo` and `getRawContent` causes test failures for me (at least when running without V8 mode). It looks like a legit mistake and I don't see any reason they wouldn't already be causing errors. LMK if I'm missing something.

Helps with #5.