### PR TITLE
Add a action_after_match field to control matching of multiple rules

### DIFF
--- a/Processor.ts
+++ b/Processor.ts
@@ -5,12 +5,12 @@ class Processor {
             // Apply each rule until matching a rule with a DONE action or matching a rule with
             // FINISH_STAGE and then exhausting all other rules in that stage.
             let min_stage = 0;
-            let stopping_stage = Number.MAX_VALUE;
+            let max_stage = Number.MAX_VALUE;
             for (const rule of session_data.rules) {
                 if (rule.stage < min_stage) {
                     continue;
                 }
-                if (rule.stage > stopping_stage) {
+                if (rule.stage > max_stage) {
                     break;
                 }
                 if (rule.condition.match(message_data)) {
@@ -23,11 +23,12 @@ class Processor {
                             endThread = true;
                             break;
                         case ActionAfterMatchType.FINISH_STAGE:
-                            stopping_stage = rule.stage;
+                        case ActionAfterMatchType.DEFAULT:
+                            max_stage = rule.stage;
                             break;
                         case ActionAfterMatchType.NEXT_STAGE:
                             min_stage = rule.stage + 1;
-                            stopping_stage = Number.MAX_VALUE;
+                            max_stage = Number.MAX_VALUE;
                             break;
                     }
                     if (endThread) {

--- a/Rule.ts
+++ b/Rule.ts
@@ -58,7 +58,7 @@ class Rule {
 
     private static parseActionAfterMatchType(str: string): ActionAfterMatchType {
         if (str.length === 0) {
-            return ActionAfterMatchType.FINISH_STAGE;
+            return ActionAfterMatchType.DEFAULT;
         }
         const result = ActionAfterMatchType[str.toUpperCase() as keyof typeof ActionAfterMatchType];
         assert(result !== undefined, `Can't parse action_after_match value ${str}.`);

--- a/ThreadAction.ts
+++ b/ThreadAction.ts
@@ -2,7 +2,7 @@ enum BooleanActionType {DEFAULT, ENABLE, DISABLE}
 
 enum InboxActionType {DEFAULT, INBOX, ARCHIVE, TRASH}
 
-enum ActionAfterMatchType {DONE, FINISH_STAGE, NEXT_STAGE}
+enum ActionAfterMatchType {DEFAULT, DONE, FINISH_STAGE, NEXT_STAGE}
 
 class ThreadAction {
 
@@ -13,7 +13,7 @@ class ThreadAction {
     public important: BooleanActionType = BooleanActionType.DEFAULT;
     public read: BooleanActionType = BooleanActionType.DEFAULT;
     public auto_label: BooleanActionType = BooleanActionType.DEFAULT;
-    public action_after_match: ActionAfterMatchType = ActionAfterMatchType.NEXT_STAGE;
+    public action_after_match: ActionAfterMatchType = ActionAfterMatchType.DEFAULT;
 
     hasAnyAction() {
         return this.label_names.size > 0


### PR DESCRIPTION
Add a column called "action_after_match" and you can override the default match behavior of finishing same stage and then terminating processing on the current thread.

Note I've only done minimal testing on it so far.

Fixes #1.