### PR TITLE
Fix checking wrong action_after_match field, always applying DEFAULT

### DIFF
--- a/Processor.ts
+++ b/Processor.ts
@@ -17,7 +17,7 @@ class Processor {
                     console.log(`rule ${rule} matches message ${message_data}, apply action ${rule.thread_action}`);
                     thread_data.thread_action.mergeFrom(rule.thread_action);
                     let endThread = false;
-                    switch (thread_data.thread_action.action_after_match) {
+                    switch (rule.thread_action.action_after_match) {
                         case ActionAfterMatchType.DONE:
                             // Break out of switch and then out of loop.
                             endThread = true;


### PR DESCRIPTION
Fixes the switch statement to check the matching rule's action_after_match instead of the thread's preexisting action_after_match, which isn't populated by thread_action.mergeFrom and always takes the DEFAULT branch regardless of the rule's value.

Fixes #1 (for real this time).