### PR TITLE
Don't override explicit inbox action with DEFAULT

### DIFF
--- a/ThreadAction.ts
+++ b/ThreadAction.ts
@@ -30,7 +30,9 @@ class ThreadAction {
 
     mergeFrom(other: Readonly<ThreadAction>): this {
         this.addLabels(Array.from(other.label_names.values()));
-        this.move_to = other.move_to;
+        if (other.move_to != InboxActionType.DEFAULT) {
+            this.move_to = other.move_to;
+        }
         for (const name of ThreadAction.ACTION_CONFIG_TYPE_FIELD_NAMES) {
             if (other[name] != BooleanActionType.DEFAULT) {
                 this[name] = other[name];


### PR DESCRIPTION
Improvement related to #1 that makes behavior more intuitive for multiple rules matching the same thread.