### PR TITLE
Clarify parsed rule logging

### DIFF
--- a/Rule.ts
+++ b/Rule.ts
@@ -125,7 +125,7 @@ class Rule {
         // sort by stage
         rules.sort((a: Rule, b: Rule) => a.stage - b.stage);
 
-        console.log(`Parsed rules:\n${rules.map(rule => rule.toString()).join("\n")}`);
+        console.log(`Parsed rules:\n${rules.map(rule => rule.toString()).join("\n---\n")}`);
 
         return rules;
     }


### PR DESCRIPTION
When inspecting the logs, it's hard for me to parse between different rules:

<img width="827" alt="Screen shot of parsed rules" src="https://user-images.githubusercontent.com/787066/84727992-e78bc800-af55-11ea-811d-79b654b2435a.png">

This adds a line between them to disambiguate.
