### PR TITLE
Removing the requirement for processed_label

### DIFF
--- a/Config.ts
+++ b/Config.ts
@@ -21,7 +21,6 @@ class Config implements Readonly<MutableConfig> {
 
     private static validate(config: Config) {
         assert(config.unprocessed_label.length > 0, "unprocessed_label can't be empty");
-        assert(config.processed_label.length > 0, "processed_label can't be empty");
         assert(config.processing_frequency_in_minutes >= 5, "processing_frequency_in_minutes can't be smaller than 5");
         assert(config.max_threads <= 100, "max_threads can't be greater than 100");
     }
@@ -29,7 +28,7 @@ class Config implements Readonly<MutableConfig> {
     public static getConfig(): Config {
         let config: MutableConfig = {
             unprocessed_label: "unprocessed",
-            processed_label: "processed",
+            processed_label: "",
             processing_failed_label: "error",
             processing_frequency_in_minutes: 5,
             hour_of_day_to_run_sanity_checking: 0,

--- a/ThreadData.ts
+++ b/ThreadData.ts
@@ -188,7 +188,7 @@ export class ThreadData {
             Logger.log(`Updated threads status.`);
 
             const all_threads = all_thread_data.map(data => data.raw);
-            if (session_data.config.processed_label > 0){
+            if (session_data.config.processed_label.length > 0){
                 session_data.getOrCreateLabel(session_data.config.processed_label).addToThreads(all_threads);
             }
             session_data.getOrCreateLabel(session_data.config.unprocessed_label).removeFromThreads(all_threads);

--- a/ThreadData.ts
+++ b/ThreadData.ts
@@ -188,7 +188,9 @@ export class ThreadData {
             Logger.log(`Updated threads status.`);
 
             const all_threads = all_thread_data.map(data => data.raw);
-            session_data.getOrCreateLabel(session_data.config.processed_label).addToThreads(all_threads);
+            if (session_data.config.processed_label > 0){
+                session_data.getOrCreateLabel(session_data.config.processed_label).addToThreads(all_threads);
+            }
             session_data.getOrCreateLabel(session_data.config.unprocessed_label).removeFromThreads(all_threads);
             Logger.log(`Mark as processed.`);
         });


### PR DESCRIPTION
The note for the "processed_label" config (in the spreadsheet) currently says:

`"May be blank to disable this"`

The current code doesn't allow this functionality and throws an error.

This pull request fixes that functionality and allows for a blank "processed_label".