### PR TITLE
Add parent labels

### DIFF
--- a/ThreadAction.test.ts
+++ b/ThreadAction.test.ts
@@ -1,0 +1,34 @@
+import ThreadAction from './ThreadAction';
+import {assert} from './utils';
+
+it('Adds parent labels', () => {
+  const labels = ['list/abc', 'bot/team1/test', 'bot/team1/alert', 'def'];
+  const action = new ThreadAction();
+  const expected = new Set(['list', 'list/abc', 'bot', 'bot/team1', 'bot/team1/test', 'bot/team1/alert', 'def'])
+
+  action.addLabels(labels);
+
+  assert(action.label_names.size === expected.size,
+    `Expected ${Array.from(expected).join(', ')},
+but got ${Array.from(action.label_names).join(', ')}`);
+
+  for (const label of expected) {
+    assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
+  }
+});
+
+it('Does not add parent labels for empty list', () => {
+  const labels: string[] = [];
+  const action = new ThreadAction();
+  const expected = new Set([])
+
+  action.addLabels(labels);
+
+  assert(action.label_names.size === expected.size,
+    `Expected ${Array.from(expected).join(', ')},
+but got ${Array.from(action.label_names).join(', ')}`);
+
+  for (const label of expected) {
+    assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
+  }
+});

--- a/ThreadAction.ts
+++ b/ThreadAction.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-enum BooleanActionType {DEFAULT, ENABLE, DISABLE}
+export enum BooleanActionType {DEFAULT, ENABLE, DISABLE}
 
-enum InboxActionType {DEFAULT, INBOX, ARCHIVE, TRASH}
+export enum InboxActionType {DEFAULT, INBOX, ARCHIVE, TRASH}
 
-enum ActionAfterMatchType {DEFAULT, DONE, FINISH_STAGE, NEXT_STAGE}
+export enum ActionAfterMatchType {DEFAULT, DONE, FINISH_STAGE, NEXT_STAGE}
 
-class ThreadAction {
+export default class ThreadAction {
 
     private static ACTION_CONFIG_TYPE_FIELD_NAMES: (keyof Pick<ThreadAction, "important" | "read" | "auto_label">)[] = ["important", "read", "auto_label"];
 
@@ -40,7 +40,12 @@ class ThreadAction {
 
     addLabels(new_label_names: string[]) {
         for (const label of new_label_names) {
-            this.label_names.add(label);
+            let remaining = label;
+            while (remaining) {
+                this.label_names.add(remaining);
+                const index = remaining.lastIndexOf('/');
+                remaining = remaining.substring(0, index);
+            }
         }
     }
 

--- a/ThreadData.ts
+++ b/ThreadData.ts
@@ -15,6 +15,7 @@
  */
 
 import {assert, withTimer} from './utils';
+import ThreadAction, {BooleanActionType, InboxActionType} from 'ThreadAction';
 
 // Represents a message in a thread
 const MAX_BODY_PROCESSING_LENGTH = 65535;

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleDirectories: ['.'],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "strictNullChecks": true,
     "experimentalDecorators": true,
     "esModuleInterop": true


### PR DESCRIPTION
Given a label structure like:

- list
  - abc
  - def

If you wanted to search all of the emails in both `list-abc` and
`list-def`, you'd need to search `label:list-abc OR label:list-def`.
This is because Gmail label nesting is actually flat, not really
hierarchical.

This change updates the labeling such that parent labels are added as
well, so searching `label:list` would give all emails in both abc and
def lists.