### PR TITLE
Fix utils.ts imports

### DIFF
--- a/Condition.ts
+++ b/Condition.ts
@@ -15,7 +15,7 @@
  */
 
 import {MessageData} from './ThreadData';
-import {assert} from './utils';
+import Utils from './utils';
 
 const RE_FLAG_PATTERN = /^\/(.*)\/([gimuys]*)$/;
 
@@ -44,7 +44,7 @@ export default class Condition {
                     break;
                 case ')':
                     level--;
-                    assert(level >= 0, `Condition ${condition_str} has non-balanced parentheses`);
+                    Utils.assert(level >= 0, `Condition ${condition_str} has non-balanced parentheses`);
                     if (level === 0) {
                         if (start < end) {
                             const sub_str = rest_str.substring(start, end + 1).trim();
@@ -57,7 +57,7 @@ export default class Condition {
                     break;
             }
         }
-        assert(level === 0, `Condition ${condition_str} has non-balanced parentheses overall.`);
+        Utils.assert(level === 0, `Condition ${condition_str} has non-balanced parentheses overall.`);
         return result;
     }
 
@@ -66,7 +66,7 @@ export default class Condition {
     }
 
     private static parseRegExp(pattern: string, condition_str: string, matching_address: boolean): RegExp {
-        assert(pattern.length > 0, `Condition ${condition_str} should have value but not found`);
+        Utils.assert(pattern.length > 0, `Condition ${condition_str} should have value but not found`);
         const match = pattern.match(RE_FLAG_PATTERN);
         if (match !== null) {
             // normal regexp
@@ -90,7 +90,7 @@ export default class Condition {
 
     constructor(condition_str: string) {
         condition_str = condition_str.trim();
-        assert(condition_str.startsWith('(') && condition_str.endsWith(')'),
+        Utils.assert(condition_str.startsWith('(') && condition_str.endsWith(')'),
             `Condition ${condition_str} should be surrounded by ().`);
         const first_space = condition_str.indexOf(" ");
         const type_str = condition_str.substring(1, first_space).trim().toUpperCase();
@@ -194,7 +194,7 @@ export default class Condition {
     public static testAll() {
         function t(condition_str: string, target_str: string, is_address: boolean, should_matching: boolean) {
             const regexp = Condition.parseRegExp(condition_str, "", is_address);
-            assert(regexp.test(target_str) === should_matching,
+            Utils.assert(regexp.test(target_str) === should_matching,
                 `Expect ${condition_str}(${regexp.source}) to match ${target_str}, but failed`);
         }
 
@@ -250,7 +250,7 @@ export default class Condition {
         function c(condition_str: string, message: Partial<GoogleAppsScript.Gmail.GmailMessage>, expected: boolean) {
             const condition = new Condition(condition_str);
             const message_data = new MessageData(Object.assign({}, base_message, message));
-            assert(condition.match(message_data) === expected,
+            Utils.assert(condition.match(message_data) === expected,
                 `Expected ${condition_str} matches email ${message}, but failed`);
         }
 

--- a/Config.ts
+++ b/Config.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-interface MutableConfig {
+import Utils from './utils';
+
+export interface MutableConfig {
     unprocessed_label: string;
     processed_label: string;
     processing_failed_label: string;
@@ -25,7 +27,7 @@ interface MutableConfig {
     auto_labeling_parent_label: string;
 }
 
-class Config implements Readonly<MutableConfig> {
+export class Config implements Readonly<MutableConfig> {
     public readonly unprocessed_label: string;
     public readonly processed_label: string;
     public readonly processing_failed_label: string;
@@ -36,9 +38,9 @@ class Config implements Readonly<MutableConfig> {
     public readonly auto_labeling_parent_label: string;
 
     private static validate(config: Config) {
-        assert(config.unprocessed_label.length > 0, "unprocessed_label can't be empty");
-        assert(config.processing_frequency_in_minutes >= 5, "processing_frequency_in_minutes can't be smaller than 5");
-        assert(config.max_threads <= 100, "max_threads can't be greater than 100");
+        Utils.assert(config.unprocessed_label.length > 0, "unprocessed_label can't be empty");
+        Utils.assert(config.processing_frequency_in_minutes >= 5, "processing_frequency_in_minutes can't be smaller than 5");
+        Utils.assert(config.max_threads <= 100, "max_threads can't be greater than 100");
     }
 
     public static getConfig(): Config {
@@ -53,7 +55,7 @@ class Config implements Readonly<MutableConfig> {
             auto_labeling_parent_label: "",
         };
 
-        const values = withTimer("GetConfigValues", () => {
+        const values = Utils.withTimer("GetConfigValues", () => {
             const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('configs');
             const num_rows = sheet.getLastRow();
             return sheet.getRange(1, 1, num_rows, 2).getDisplayValues().map(row => row.map(cell => cell.trim()));

--- a/Rule.ts
+++ b/Rule.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-class Rule {
+import Utils from './utils';
+import Condition from "./Condition";
+import ThreadAction, {ActionAfterMatchType, BooleanActionType, InboxActionType} from './ThreadAction';
+
+export class Rule {
 
     public readonly condition: Condition;
     public readonly thread_action: Readonly<ThreadAction>;
@@ -68,7 +72,7 @@ class Rule {
             return InboxActionType.DEFAULT;
         }
         const result = InboxActionType[str.toUpperCase() as keyof typeof InboxActionType];
-        assert(result !== undefined, `Can't parse inbox action value ${str}.`);
+        Utils.assert(result !== undefined, `Can't parse inbox action value ${str}.`);
         return result;
     }
 
@@ -77,12 +81,12 @@ class Rule {
             return ActionAfterMatchType.DEFAULT;
         }
         const result = ActionAfterMatchType[str.toUpperCase() as keyof typeof ActionAfterMatchType];
-        assert(result !== undefined, `Can't parse action_after_match value ${str}.`);
+        Utils.assert(result !== undefined, `Can't parse action_after_match value ${str}.`);
         return result;
     }
 
     public static getRules(): Rule[] {
-        const values: string[][] = withTimer("GetRuleValues", () => {
+        const values: string[][] = Utils.withTimer("GetRuleValues", () => {
             const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('rules');
             const column_num = sheet.getLastColumn();
             const row_num = sheet.getLastRow();

--- a/SessionData.ts
+++ b/SessionData.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-class SessionData {
+import Utils from './utils';
+import {Config} from './Config'
+import {Rule} from './Rule'
+
+export class SessionData {
 
     private static getLabelMap(): { [key: string]: GoogleAppsScript.Gmail.GmailLabel } {
         let labels: { [key: string]: GoogleAppsScript.Gmail.GmailLabel } = {};
@@ -33,10 +37,10 @@ class SessionData {
     public readonly oldest_to_process: Date;
 
     constructor() {
-        this.user_email = withTimer("getEmail", () => Session.getActiveUser().getEmail());
-        this.config = withTimer("getConfigs", () => Config.getConfig());
-        this.labels = withTimer("getLabels", () => SessionData.getLabelMap());
-        this.rules = withTimer("getRules", () => Rule.getRules());
+        this.user_email = Utils.withTimer("getEmail", () => Session.getActiveUser().getEmail());
+        this.config = Utils.withTimer("getConfigs", () => Config.getConfig());
+        this.labels = Utils.withTimer("getLabels", () => SessionData.getLabelMap());
+        this.rules = Utils.withTimer("getRules", () => Rule.getRules());
 
         this.processing_start_time = new Date();
         // Check back two processing intervals to make sure we checked all messages in the thread
@@ -46,7 +50,7 @@ class SessionData {
 
     getOrCreateLabel(name: string) {
         name = name.trim();
-        assert(name.length > 0, "Can't get empty label!");
+        Utils.assert(name.length > 0, "Can't get empty label!");
 
         if (!(name in this.labels)) {
             // Also create parent labels too if necessary.

--- a/Stats.ts
+++ b/Stats.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-class Stats {
+export class Stats {
 
     private static RECORD_SHEET_NAME = 'statistics';
     private static SUMMARY_SHEET_NAME = 'daily_stats';

--- a/ThreadAction.test.ts
+++ b/ThreadAction.test.ts
@@ -1,5 +1,5 @@
-import ThreadAction from './ThreadAction';
-import {assert} from './utils';
+import ThreadAction  from './ThreadAction';
+import Utils from './utils';
 
 it('Adds parent labels', () => {
   const labels = ['list/abc', 'bot/team1/test', 'bot/team1/alert', 'def'];
@@ -8,27 +8,21 @@ it('Adds parent labels', () => {
 
   action.addLabels(labels);
 
-  assert(action.label_names.size === expected.size,
+  Utils.assert(action.label_names.size === expected.size,
     `Expected ${Array.from(expected).join(', ')},
 but got ${Array.from(action.label_names).join(', ')}`);
 
   for (const label of expected) {
-    assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
+    Utils.assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
   }
 });
 
 it('Does not add parent labels for empty list', () => {
   const labels: string[] = [];
   const action = new ThreadAction();
-  const expected = new Set([])
 
   action.addLabels(labels);
 
-  assert(action.label_names.size === expected.size,
-    `Expected ${Array.from(expected).join(', ')},
-but got ${Array.from(action.label_names).join(', ')}`);
-
-  for (const label of expected) {
-    assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
-  }
+  Utils.assert(action.label_names.size === 0,
+    `Expected empty set, but got ${Array.from(action.label_names).join(', ')}`);
 });

--- a/ThreadData.ts
+++ b/ThreadData.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {assert, withTimer} from './utils';
-import ThreadAction, {BooleanActionType, InboxActionType} from 'ThreadAction';
+import Utils from './utils';
+import ThreadAction, {BooleanActionType, InboxActionType} from './ThreadAction';
+import {SessionData} from './SessionData';
 
 // Represents a message in a thread
 const MAX_BODY_PROCESSING_LENGTH = 65535;
@@ -49,7 +50,7 @@ export class MessageData {
         }
         for (const part of parts) {
             const [type, address] = part.trim().split(/\s+/);
-            assert(typeof address !== 'undefined', `Unexpected mailing list: ${match[1].trim()}`);
+            Utils.assert(typeof address !== 'undefined', `Unexpected mailing list: ${match[1].trim()}`);
             if (type.trim() === 'list') {
                 return address;
             }
@@ -160,7 +161,7 @@ export class ThreadData {
             read_action_map.get(action.read)!.push(thread);
         });
 
-        withTimer("BatchApply", () => {
+        Utils.withTimer("BatchApply", () => {
             // batch update labels
             for (const label_name in label_action_map) {
                 const threads = label_action_map[label_name];

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,9 @@
 
 // Polyfills
 
+import Condition from './Condition'
+import {Processor} from './Processor'
+
 // String.startsWith polyfill
 if (!String.prototype.startsWith) {
     Object.defineProperty(String.prototype, 'startsWith', {
@@ -91,11 +94,11 @@ function onOpen(e: { authMode: GoogleAppsScript.Script.AuthMode }) {
 
 // Triggered when time-driven trigger or click via Spreadsheet menu
 function processEmails() {
-    withFailureEmailed("processEmails", () => Processor.processAllUnprocessedThreads());
+    Utils.withFailureEmailed("processEmails", () => Processor.processAllUnprocessedThreads());
 }
 
 function sanityChecking() {
-    withFailureEmailed("sanityChecking", () => {
+    Utils.withFailureEmailed("sanityChecking", () => {
         Stats.collapseStatRecords();
     });
 }
@@ -103,9 +106,9 @@ function sanityChecking() {
 function setupTriggers() {
     cancelTriggers();
 
-    withFailureEmailed("setupTriggers", () => {
-        const config = withTimer("getConfigs", () => Config.getConfig());
-        withTimer("addingTriggers", () => {
+    Utils.withFailureEmailed("setupTriggers", () => {
+        const config = Utils.withTimer("getConfigs", () => Config.getConfig());
+        Utils.withTimer("addingTriggers", () => {
             let trigger = ScriptApp.newTrigger('processEmails')
                 .timeBased()
                 .everyMinutes(config.processing_frequency_in_minutes)
@@ -118,7 +121,7 @@ function setupTriggers() {
                 .create();
             Logger.log(`Created trigger ${trigger.getHandlerFunction()}: ${trigger.getUniqueId()}`);
 
-            assert(ScriptApp.getProjectTriggers().length === 2,
+            Utils.assert(ScriptApp.getProjectTriggers().length === 2,
                 `Unexpected trigger lists: ${ScriptApp.getProjectTriggers()
                     .map(trigger => trigger.getHandlerFunction())}`);
         });
@@ -126,7 +129,7 @@ function setupTriggers() {
 }
 
 function cancelTriggers() {
-    withFailureEmailed("cancelTriggers", () => {
+    Utils.withFailureEmailed("cancelTriggers", () => {
         ScriptApp.getProjectTriggers().forEach(trigger => {
             Logger.log(`Deleting trigger ${trigger.getHandlerFunction()}...`);
             ScriptApp.deleteTrigger(trigger);

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  moduleDirectories: ['.'],
 };

--- a/utils.ts
+++ b/utils.ts
@@ -14,34 +14,36 @@
  * limitations under the License.
  */
 
-export function assert(condition: boolean, msg: string) {
-    if (!condition) {
-        throw msg;
+export default class Utils {
+    public static assert = function(condition: boolean, msg: string) {
+        if (!condition) {
+            throw msg;
+        }
     }
-}
 
-export function withTimer<T>(taskName: string, func: () => T): T {
-    const startTime = new Date();
-    try {
-        const res = func();
-        Logger.log(`Finished ${taskName} successfully in ${new Date().getTime() - startTime.getTime()}ms`);
-        return res;
-    } catch (e) {
-        Logger.log(
-            `Finished ${taskName} failed in ${new Date().getTime() - startTime.getTime()}ms: ${e.name}\nMessage: ${e.message}`);
-        throw e;
+    public static withTimer = function<T>(taskName: string, func: () => T): T {
+        const startTime = new Date();
+        try {
+            const res = func();
+            Logger.log(`Finished ${taskName} successfully in ${new Date().getTime() - startTime.getTime()}ms`);
+            return res;
+        } catch (e) {
+            Logger.log(
+                `Finished ${taskName} failed in ${new Date().getTime() - startTime.getTime()}ms: ${e.name}\nMessage: ${e.message}`);
+            throw e;
+        }
     }
-}
 
-export function withFailureEmailed<T>(taskName: string, func: () => T): T {
-    try {
-        return withTimer(taskName, func);
-    } catch (e) {
-        // Email exceptions
-        GmailApp.sendEmail(
-            Session.getActiveUser().getEmail(),
-            'Log for failure in Gmail Automata',
-            `Captured an error: ${e}\n\n${Logger.getLog()}`);
-        throw e;
+    public static withFailureEmailed = function<T>(taskName: string, func: () => T): T {
+        try {
+            return Utils.withTimer(taskName, func);
+        } catch (e) {
+            // Email exceptions
+            GmailApp.sendEmail(
+                Session.getActiveUser().getEmail(),
+                'Log for failure in Gmail Automata',
+                `Captured an error: ${e}\n\n${Logger.getLog()}`);
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
[ES imports are not supported by
Clasp](https://github.com/google/clasp/blob/master/docs/typescript.md#modules-exports-and-imports).
The work-around that we seem to have been relying on is that classes are
still global after the typescript build, so this simply puts the util
functions in a class as static functions for namespacing. This allows
the unit tests to still resolve imports, but the Clasp build works.