### PR TITLE
Refactor tests to run individually.

### DIFF
--- a/Config.ts
+++ b/Config.ts
@@ -57,6 +57,9 @@ export class Config implements Readonly<MutableConfig> {
 
         const values = Utils.withTimer("GetConfigValues", () => {
             const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('configs');
+            if (sheet === null) {
+                throw "Active sheet 'configs' not found";
+            }
             const num_rows = sheet.getLastRow();
             return sheet.getRange(1, 1, num_rows, 2).getDisplayValues().map(row => row.map(cell => cell.trim()));
         });

--- a/JestSheets.ts
+++ b/JestSheets.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Creates light-weight Jest-compatible functions that can be run on
+// an active Sheet.
+
+class JestResultError extends Error {
+    constructor(msg: string) {
+        super(msg);
+        // Set prototype explicitly for TypeScript Breaking-Changes
+        Object.setPrototypeOf(this, JestResultError.prototype);
+    }
+}
+
+class JestExpectOperand {
+    private readonly actual: any;
+    constructor(actual: any) {
+        this.actual = actual;
+    }
+
+    toBe(expected: any) {
+        if (this.actual !== expected) {
+            throw new JestResultError(`Expected: ${expected}, Actual: ${this.actual}`);
+        }
+    }
+
+    toEqual(expected: any) {
+        if (Array.isArray(this.actual) && Array.isArray(expected)) {
+            if (this.actual.length != expected.length) {
+                throw new JestResultError(
+                    `Arrays are wrong size. Expected: ${expected.length}, Actual: ${this.actual.length}`);
+            }
+            expected.every((item, index) => {
+                if (item != this.actual[index]) {
+                    throw new JestResultError(`Expected '${item}' in array, but got '${this.actual[item]}'`)
+                }
+            });
+        } else if (this.actual instanceof Set && expected instanceof Set) {
+            if (this.actual.size != expected.size) {
+                throw new JestResultError(
+                    `Sets are wrong size. Expected: ${expected.size}, Actual: ${this.actual.size}`);
+            }
+            expected.forEach(item => {
+                if (!this.actual.has(item)) {
+                    throw new JestResultError(`Expected '${item}' in Set.`)
+                }
+            });
+        } else {
+            throw new Error(`'toEqual' currently only supports Arrays/Sets, but got '${typeof expected}'`);
+        }
+    }
+
+    toBeGreaterThan(expected: any) {
+        if (this.actual <= expected) {
+            throw new JestResultError(`Expected: ${expected} to be Greater Than Actual: ${this.actual}`);
+        }
+    }
+
+    toThrow() {
+        if (typeof this.actual !== 'function') {
+            throw new Error('Test expects a function');
+        }
+        try {
+            this.actual();
+            throw new JestResultError(`Expected to throw exception, but didn't`);
+        }
+        catch {
+        }
+    }
+}
+
+export class JestExpect {
+    expect(actual: any) {
+        return new JestExpectOperand(actual);
+    }
+}
+
+export class JestIt {
+    it(message: string, test_function_callback: Function) {
+        try {
+            test_function_callback();
+        }
+        catch(e) {
+            if (e instanceof JestResultError) {
+                throw new Error(`Test Failure: ${message}. ${e.message}`);
+            } else {
+                throw e;
+            }
+        }
+    }
+}
+

--- a/Mocks.ts
+++ b/Mocks.ts
@@ -1,0 +1,132 @@
+import {SessionData} from "./SessionData";
+import {Config} from "./Config";
+
+
+export default class Mocks {
+
+    private static base_config: Config = {
+        auto_labeling_parent_label: "",
+        go_link: "",
+        hour_of_day_to_run_sanity_checking: 0,
+        max_threads: 50,
+        processed_label: "myProcessed",
+        processing_failed_label: "zFailed",
+        processing_frequency_in_minutes: 5,
+        unprocessed_label: "myUnprocessed",
+    };
+
+    public static getMockConfig = (overrides: Partial<Config> = {}) => (
+        Object.assign({}, Mocks.base_config, overrides)
+    );
+    
+    private static base_session_data: SessionData = {
+        user_email: "abc@gmail.com",
+        config: Mocks.getMockConfig(),
+        labels: {},
+        rules: [],
+        processing_start_time: new Date(12345),
+        oldest_to_process: new Date(23456),
+        getOrCreateLabel: () => ({} as GoogleAppsScript.Gmail.GmailLabel),
+    };
+
+    public static getMockSessionData = (overrides: Partial<SessionData> = {}) => (
+        Object.assign({}, Mocks.base_session_data, overrides)
+    );
+
+    private static base_label = {
+        getName: () => '',
+    } as GoogleAppsScript.Gmail.GmailLabel;
+
+    private static base_thread = {
+        getLabels: () => [Mocks.base_label],
+        isImportant: () => false,
+        isInInbox: () => false,
+        isInPriorityInbox: () => false,
+        isInSpam: () => false,
+        isInTrash: () => false,
+        hasStarredMessages: () => false,
+        isUnread: () => false,
+        getFirstMessageSubject: () => '',
+        getMessages: () => [],
+    } as unknown as GoogleAppsScript.Gmail.GmailThread;
+
+    private static base_message = {
+        getFrom: () => '',
+        getTo: () => '',
+        getCc: () => '',
+        getBcc: () => '',
+        getReplyTo: () => '',
+        getSubject: () => '',
+        getPlainBody: () => '',
+        getRawContent: () => '',
+        getHeader: (_name: string) => '',
+        getDate: () => Date.now() as unknown as GoogleAppsScript.Base.Date,
+        getThread: () => Mocks.base_thread
+    } as GoogleAppsScript.Gmail.GmailMessage;
+
+    public static getMockMessage = (
+        override_message: Partial<GoogleAppsScript.Gmail.GmailMessage> = {},
+        override_thread: Partial<GoogleAppsScript.Gmail.GmailThread> = {},
+        labels: string[] = []): GoogleAppsScript.Gmail.GmailMessage => {
+        const gmail_labels: GoogleAppsScript.Gmail.GmailLabel[] = [];
+        labels.forEach(label => {
+            gmail_labels.push(Object.assign({}, Mocks.base_label, {getName: () => label}));
+        });
+        let overridden_thread: GoogleAppsScript.Gmail.GmailThread =
+            Object.assign({}, Mocks.base_thread, override_thread);
+        overridden_thread = Object.assign({}, overridden_thread, {getLabels: () => gmail_labels});
+        let overridden_message = Object.assign({}, Mocks.base_message, override_message);
+        overridden_message = Object.assign({}, overridden_message, {getThread: () => overridden_thread});
+        return overridden_message;
+    };
+
+    public static getMockThreadOfMessages = (
+        override_messages: Partial<GoogleAppsScript.Gmail.GmailMessage>[] = [{}],
+        override_thread: Partial<GoogleAppsScript.Gmail.GmailThread> = {},
+        labels: string[] = []): GoogleAppsScript.Gmail.GmailThread => {
+        const gmail_labels: GoogleAppsScript.Gmail.GmailLabel[] = [];
+        labels.forEach(label => {
+            gmail_labels.push(Object.assign({}, Mocks.base_label, {getName: () => label}));
+        });
+        const messages: GoogleAppsScript.Gmail.GmailMessage[] = [];
+        let overridden_thread: GoogleAppsScript.Gmail.GmailThread =
+            Object.assign({}, Mocks.base_thread, override_thread);
+        overridden_thread = Object.assign(
+            {}, overridden_thread, {
+                getMessages: () => messages,
+                getLabels: () => gmail_labels,
+            });
+
+        override_messages.forEach(message => {
+            let overridden_message = Object.assign({}, Mocks.base_message, message);
+            overridden_message = Object.assign({}, overridden_message, {getThread: () => overridden_thread});                
+            messages.push(overridden_message);
+        });
+        return overridden_thread;
+    };
+
+    public static getMockTestSheetHeaders(): string[] {
+        return [
+            "conditions", "add_labels", "move_to", "mark_important",
+            "mark_read", "stage", "auto_label", "disabled", "action_after_match"];
+    }
+
+    public static getMockTestSheet = (
+        rows: { [key: string]: string}[],
+        headers: string[] = Mocks.getMockTestSheetHeaders()): string[][] => {
+        const sheet: string[][] = [headers];
+        rows.forEach(row_details => {
+            const row: string[] = [];
+            for (const header in headers) {
+                const header_name = headers[header];
+                if (header_name in row_details) {
+                    row.push(row_details[header_name]);
+                } else {
+                    row.push("");
+                }
+            }
+            sheet.push(row);
+        });
+        return sheet;
+    }
+}

--- a/Processor.test.ts
+++ b/Processor.test.ts
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import Condition from './Condition';
+import {Processor} from './Processor';
 
-describe('Condition Regex Parsing and Matching', () => {
-    Condition.testRegex(it, expect);
-})
-
-describe('Condition Building', () => {
-    Condition.testConditionParsing(it, expect);
+describe('Processor Tests', () => {
+    Processor.testProcessing(it, expect);
 })

--- a/Processor.ts
+++ b/Processor.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import {ActionAfterMatchType, InboxActionType} from './ThreadAction';
-import {SessionData} from 'SessionData';
-import {ThreadData} from './ThreadData'
+import {SessionData} from './SessionData';
+import {ThreadData} from './ThreadData';
+import {Stats} from './Stats';
 import Utils from './utils';
 
 export class Processor {

--- a/Processor.ts
+++ b/Processor.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ActionAfterMatchType, InboxActionType} from './ThreadAction';
+import {ActionAfterMatchType, BooleanActionType, InboxActionType} from './ThreadAction';
 import {SessionData} from './SessionData';
 import {ThreadData} from './ThreadData';
 import {Stats} from './Stats';
 import Utils from './utils';
+import Mocks from './Mocks';
+import {Rule} from './Rule';
 
 export class Processor {
 
@@ -117,5 +119,71 @@ export class Processor {
             () => Stats.addStatRecord(start_time, processed_thread_count, processed_message_count));
 
         Utils.assert(all_pass, `Some processing fails, check emails`);
+    }
+
+    public static testProcessing(it: Function, expect: Function) {
+        function test_proc(
+            sheet_rows: { [key: string]: string}[] = [],
+            thread_messages: Partial<GoogleAppsScript.Gmail.GmailMessage>[] = [],
+            thread: Partial<GoogleAppsScript.Gmail.GmailThread> = {}
+            ): ThreadData {
+
+            const sheet = Mocks.getMockTestSheet(sheet_rows);
+            const rules = Rule.parseRules(sheet);
+            const session_data = Mocks.getMockSessionData({rules: rules});
+            const mock_gmail_thread = Mocks.getMockThreadOfMessages(thread_messages, thread);
+            const thread_data = new ThreadData(session_data, mock_gmail_thread);
+
+            Processor.processThread(session_data, thread_data);
+            return thread_data;
+        }
+
+        it('Throws error when message does not match any rule', () => {
+            expect(() => {
+                test_proc([
+                    {
+                        conditions: '(sender xyz@gmail.com)',
+                        stage: '5',
+                    },
+                ], [
+                    {
+                        getFrom: () => 'abc@gmail.com',
+                    }
+                ])
+            }).toThrow();
+        })
+        it('Does basic actions for simple rule and message', () => {
+            const thread_data = test_proc([
+                {
+                    conditions: '(sender xyz@gmail.com)',
+                    add_labels: 'abc, xyz',
+                    stage: '5',
+                },
+            ], [
+                {
+                    getFrom: () => 'xyz@gmail.com',
+                }
+            ]);
+
+            expect(thread_data.thread_action.action_after_match).toBe(ActionAfterMatchType.DEFAULT);
+            expect(thread_data.thread_action.important).toBe(BooleanActionType.DEFAULT);
+            expect(thread_data.thread_action.label_names).toEqual(new Set(['abc', 'xyz']));
+            expect(thread_data.thread_action.move_to).toBe(InboxActionType.DEFAULT);
+            expect(thread_data.thread_action.read).toBe(BooleanActionType.DEFAULT);
+        })
+        it('Throws error when message matches action but has no actions', () => {
+            expect(() => {
+                test_proc([
+                    {
+                        conditions: '(sender xyz@gmail.com)',
+                        stage: '5',
+                    },
+                ], [
+                    {
+                        getFrom: () => 'xyz@gmail.com',
+                        }
+                ])
+            }).toThrow();
+        })
     }
 }

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Click menu "Gmail Automata" -> "Stop auto processing" to remove auto triggering.
 3. Update the script id in ".clasp.json" file. To find the script id:
     1. Setup the script following the section [Setup](#Setup) above if you
     haven't do it.
-    2. In the spreadsheet, click menu "Extensions" -> "App Script".
+    2. In the spreadsheet, click menu "Extensions" -> "Apps Script".
     3. In the script editor, click menu "Project Settings" > "IDs" > "ScriptID".
 4. Login CLASP: `yarn claspLogin` and authorize the app in the browser.
 5. Deploy current version: `yarn deploy`.

--- a/Rule.test.ts
+++ b/Rule.test.ts
@@ -1,0 +1,5 @@
+import { Rule } from "./Rule";
+
+describe('Rules Load Correctly', () => {
+    Rule.testRules(it, expect);
+})

--- a/Rule.ts
+++ b/Rule.ts
@@ -88,6 +88,9 @@ export class Rule {
     public static getRules(): Rule[] {
         const values: string[][] = Utils.withTimer("GetRuleValues", () => {
             const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('rules');
+            if (sheet === null) {
+                throw "Active sheet 'rules' not found";
+            }
             const column_num = sheet.getLastColumn();
             const row_num = sheet.getLastRow();
             return sheet.getRange(1, 1, row_num, column_num)

--- a/Rule.ts
+++ b/Rule.ts
@@ -16,6 +16,7 @@
 
 import Utils from './utils';
 import Condition from "./Condition";
+import Mocks from "./Mocks";
 import ThreadAction, {ActionAfterMatchType, BooleanActionType, InboxActionType} from './ThreadAction';
 
 export class Rule {
@@ -85,18 +86,7 @@ export class Rule {
         return result;
     }
 
-    public static getRules(): Rule[] {
-        const values: string[][] = Utils.withTimer("GetRuleValues", () => {
-            const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('rules');
-            if (sheet === null) {
-                throw "Active sheet 'rules' not found";
-            }
-            const column_num = sheet.getLastColumn();
-            const row_num = sheet.getLastRow();
-            return sheet.getRange(1, 1, row_num, column_num)
-                .getDisplayValues()
-                .map(row => row.map(cell => cell.trim()));
-        });
+    public static parseRules(values: string[][]): Rule[] {
         const row_num = values.length;
         const column_num = values[0].length;
 
@@ -118,6 +108,13 @@ export class Rule {
                 throw `Invalid rule header:"${name}"`;
             }
             header_map[name] = column;
+        }
+
+        // Ensure all expected headers exist
+        for (const header_name in header_map) {
+            if (header_map[header_name] < 0) {
+                throw `Missing rule header: ${header_name}`;
+            }
         }
 
         // get rest rows
@@ -148,8 +145,99 @@ export class Rule {
         // sort by stage
         rules.sort((a: Rule, b: Rule) => a.stage - b.stage);
 
-        console.log(`Parsed rules:\n${rules.map(rule => rule.toString()).join("\n---\n")}`);
-
         return rules;
+    }
+
+    public static getRules(): Rule[] {
+        const values: string[][] = Utils.withTimer("GetRuleValues", () => {
+            const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('rules');
+            if (sheet === null) {
+                throw "Active sheet 'rules' not found";
+            }
+            const column_num = sheet.getLastColumn();
+            const row_num = sheet.getLastRow();
+            return sheet.getRange(1, 1, row_num, column_num)
+                .getDisplayValues()
+                .map(row => row.map(cell => cell.trim()));
+        });
+        const rules = Rule.parseRules(values);
+        console.log(`Parsed rules:\n${rules.map(rule => rule.toString()).join("\n---\n")}`);
+        return rules;
+    }
+
+    public static testRules(it: Function, expect: Function) {
+        if (typeof SpreadsheetApp !== 'undefined') {
+            // This can only be tested in the Sheet
+
+            it('Reads in default rules from Sheet', () => {
+                const rules = Rule.getRules();
+                expect(rules.length).toBeGreaterThan(0);
+            });
+        }
+
+        it('Reads in Header', () => {
+            const sheet = Mocks.getMockTestSheet([]);
+            const rules = Rule.parseRules(sheet);
+
+            expect(rules.length).toBe(0);
+        })
+
+        it('Fails with header missing item', () => {
+            const sheet = Mocks.getMockTestSheet([]);
+            sheet[0] = sheet[0].slice(0, -2);
+
+            expect(() => {Rule.parseRules(sheet)}).toThrow();
+        })
+
+        it('Loads Empty Rules', () => {
+            const sheet = Mocks.getMockTestSheet([{}, {}]);
+
+            const rules = Rule.parseRules(sheet);
+
+            expect(rules.length).toBe(0);
+        })
+
+        it('Loads Simple Rule', () => {
+            const sheet = Mocks.getMockTestSheet([
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc, xyz',
+                    stage: "5",
+                }]);
+
+            const rules = Rule.parseRules(sheet);
+
+            expect(rules.length).toBe(1);
+            expect(rules[0].stage).toBe(5);
+            expect(rules[0].thread_action.label_names.size).toBe(2);
+        })
+
+        it('Loaded Rules are sorted by stage', () => {
+            const sheet = Mocks.getMockTestSheet([
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc, xyz',
+                    stage: "5",
+                },
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc, xyz',
+                    stage: "15",
+                },
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc, xyz',
+                    stage: "1",
+                }
+            ]);
+
+            const rules = Rule.parseRules(sheet);
+
+            expect(rules.length).toBe(3);
+            expect(rules[0].stage).toBe(1);
+            expect(rules[1].stage).toBe(5);
+            expect(rules[2].stage).toBe(15);
+        })
+
     }
 }

--- a/SessionData.ts
+++ b/SessionData.ts
@@ -30,7 +30,7 @@ export class SessionData {
 
     public readonly user_email: string;
     public readonly config: Config;
-    private readonly labels: { [key: string]: GoogleAppsScript.Gmail.GmailLabel };
+    public readonly labels: { [key: string]: GoogleAppsScript.Gmail.GmailLabel };
     public readonly rules: Rule[];
 
     public readonly processing_start_time: Date;

--- a/Stats.ts
+++ b/Stats.ts
@@ -23,7 +23,7 @@ export class Stats {
         start_time: Date, processed_thread_count: number, processed_message_count: number) {
         const statsSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(Stats.RECORD_SHEET_NAME);
         if (!statsSheet) {
-            Logger.log('Couldn\'t find stats sheet!');
+            Logger.log(`Could not find "${Stats.RECORD_SHEET_NAME}" sheet!`);
             return;
         }
         const duration = new Date().getTime() - start_time.getTime();
@@ -34,6 +34,14 @@ export class Stats {
         const spread_sheet = SpreadsheetApp.getActiveSpreadsheet();
         const record_sheet = spread_sheet.getSheetByName(Stats.RECORD_SHEET_NAME);
         const summary_sheet = spread_sheet.getSheetByName(Stats.SUMMARY_SHEET_NAME);
+        if (!record_sheet) {
+            Logger.log(`Could not find "${Stats.RECORD_SHEET_NAME}" sheet!`);
+            return;
+        }
+        if (!summary_sheet) {
+            Logger.log(`Could not find "${Stats.SUMMARY_SHEET_NAME}" sheet!`);
+            return;
+        }
 
         let execution_count = 0;
 

--- a/ThreadAction.test.ts
+++ b/ThreadAction.test.ts
@@ -1,28 +1,5 @@
-import ThreadAction  from './ThreadAction';
-import Utils from './utils';
+import ThreadAction from './ThreadAction';
 
-it('Adds parent labels', () => {
-  const labels = ['list/abc', 'bot/team1/test', 'bot/team1/alert', 'def'];
-  const action = new ThreadAction();
-  const expected = new Set(['list', 'list/abc', 'bot', 'bot/team1', 'bot/team1/test', 'bot/team1/alert', 'def'])
-
-  action.addLabels(labels);
-
-  Utils.assert(action.label_names.size === expected.size,
-    `Expected ${Array.from(expected).join(', ')},
-but got ${Array.from(action.label_names).join(', ')}`);
-
-  for (const label of expected) {
-    Utils.assert(action.label_names.has(label), `Expected label ${label}, but not present in action.`);
-  }
-});
-
-it('Does not add parent labels for empty list', () => {
-  const labels: string[] = [];
-  const action = new ThreadAction();
-
-  action.addLabels(labels);
-
-  Utils.assert(action.label_names.size === 0,
-    `Expected empty set, but got ${Array.from(action.label_names).join(', ')}`);
-});
+describe('ThreadAction Tests', () => {
+  ThreadAction.testThreadActions(it, expect);
+})

--- a/ThreadAction.ts
+++ b/ThreadAction.ts
@@ -76,4 +76,72 @@ export default class ThreadAction {
         }
         return result;
     }
+
+    static testThreadActions(it: Function, expect: Function) {
+        it('Adds parent labels', () => {
+            const labels = ['list/abc', 'bot/team1/test', 'bot/team1/alert', 'def'];
+            const action = new ThreadAction();
+            const expected = new Set(['list', 'list/abc', 'bot', 'bot/team1', 'bot/team1/test', 'bot/team1/alert', 'def'])
+          
+            action.addLabels(labels);
+          
+            expect(action.label_names).toEqual(expected);
+        });
+
+        it('Does not add parent labels for empty list', () => {
+            const labels: string[] = [];
+            const action = new ThreadAction();
+            
+            action.addLabels(labels);
+            
+            expect(action.label_names.size).toBe(0);
+        });
+
+        it('Uses Default action for rules', () => {
+            const thread_data_action = new ThreadAction();
+
+            expect(thread_data_action.move_to).toBe(InboxActionType.DEFAULT);
+        });
+
+        it('Default Actions for message', () => {
+            const message_action = new ThreadAction();
+            
+            expect(message_action.move_to).toBe(InboxActionType.DEFAULT);
+            expect(message_action.important).toBe(BooleanActionType.DEFAULT);
+            expect(message_action.read).toBe(BooleanActionType.DEFAULT);
+        });
+
+        it('Merges the final Actions from a single rule', () => {
+            const message_action = new ThreadAction();
+            const rule1_action = new ThreadAction;
+            rule1_action.move_to = InboxActionType.ARCHIVE;
+            rule1_action.important = BooleanActionType.ENABLE;
+            rule1_action.read = BooleanActionType.ENABLE;
+            
+            message_action.mergeFrom(rule1_action);
+            
+            expect(message_action.move_to).toBe(InboxActionType.ARCHIVE);
+            expect(message_action.important).toBe(BooleanActionType.ENABLE);
+            expect(message_action.read).toBe(BooleanActionType.ENABLE);
+        });
+
+        it('Merges the final Actions from multiple rules', () => {
+            const message_action = new ThreadAction();
+            const rule1_action = new ThreadAction;
+            const rule2_action = new ThreadAction;
+            rule1_action.move_to = InboxActionType.ARCHIVE;
+            rule1_action.important = BooleanActionType.ENABLE;
+            rule1_action.read = BooleanActionType.ENABLE;
+            rule2_action.move_to = InboxActionType.TRASH;
+            rule2_action.important = BooleanActionType.DISABLE;
+            rule2_action.read = BooleanActionType.DISABLE;
+
+            message_action.mergeFrom(rule1_action);
+            message_action.mergeFrom(rule2_action);
+
+            expect(message_action.move_to).toBe(InboxActionType.TRASH);
+            expect(message_action.important).toBe(BooleanActionType.DISABLE);
+            expect(message_action.read).toBe(BooleanActionType.DISABLE);
+        });
+    }
 }

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,11 @@
 
 // Polyfills
 
-import Condition from './Condition'
-import {Processor} from './Processor'
+import Condition from './Condition';
+import {Config} from './Config';
+import {Processor} from './Processor';
+import {Stats} from './Stats';
+import Utils from './utils';
 
 // String.startsWith polyfill
 if (!String.prototype.startsWith) {

--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,11 @@
 
 import Condition from './Condition';
 import {Config} from './Config';
+import {JestExpect, JestIt} from './JestSheets';
 import {Processor} from './Processor';
+import {Rule} from './Rule';
 import {Stats} from './Stats';
+import ThreadAction from './ThreadAction';
 import Utils from './utils';
 
 // String.startsWith polyfill
@@ -141,5 +144,12 @@ function cancelTriggers() {
 }
 
 function testAll() {
-    Condition.testAll();
+    const jestExpect = new JestExpect();
+    const jestIt = new JestIt();
+
+    Condition.testRegex(jestIt.it, jestExpect.expect);
+    Condition.testConditionParsing(jestIt.it, jestExpect.expect);
+    Rule.testRules(jestIt.it, jestExpect.expect);
+    ThreadAction.testThreadActions(jestIt.it, jestExpect.expect);
+    Processor.testProcessing(jestIt.it, jestExpect.expect);
 }


### PR DESCRIPTION
## Background

Previously when running `yarn test`, the test results did not specify
which test actually failed. Now they will specify the exact tests that fail.

When running tests, there is a single test that runs 30+ sub-tests.
If there is a failure, there is no information about which of the 30 tests
that fails.

If we switch to more of a 'native' Jest testing structure, we can see the
individual test results. But due to limitations in Clasp, we can no longer
easily run the testsuite from the DEBUG menu.

## Test Refactoring

This change includes modifications to allow both a more 'native' Jest
environment, as well as retaining the ability to run tests in the Sheet.

Example Passing Tests:

![image](https://user-images.githubusercontent.com/15711477/182013322-88a448fa-dd3c-4fdf-8048-c90a1d43537c.png)

Example Failing Tests:

![image](https://user-images.githubusercontent.com/15711477/182013330-6efb912e-1599-4e21-85d2-7d6cac84c633.png)

Example Failing Tests in Sheets:

![image](https://user-images.githubusercontent.com/15711477/182013334-c1fa2dd1-c887-4112-a119-c2822aeb65b5.png)
