### PR TITLE
Add configuration for parent_labeling.

### DIFF
--- a/Config.ts
+++ b/Config.ts
@@ -25,6 +25,7 @@ export interface MutableConfig {
     go_link: string;
     max_threads: number;
     auto_labeling_parent_label: string;
+    parent_labeling: boolean;
 }
 
 export class Config implements Readonly<MutableConfig> {
@@ -36,6 +37,7 @@ export class Config implements Readonly<MutableConfig> {
     public readonly go_link: string;
     public readonly max_threads: number;
     public readonly auto_labeling_parent_label: string;
+    public readonly parent_labeling: boolean;
 
     private static validate(config: Config) {
         Utils.assert(config.unprocessed_label.length > 0, "unprocessed_label can't be empty");
@@ -53,6 +55,7 @@ export class Config implements Readonly<MutableConfig> {
             go_link: "",
             max_threads: 50,
             auto_labeling_parent_label: "",
+            parent_labeling: true,
         };
 
         const values = Utils.withTimer("GetConfigValues", () => {
@@ -72,6 +75,7 @@ export class Config implements Readonly<MutableConfig> {
             }
 
             switch (name) {
+                // Integer Config Values
                 case "processing_frequency_in_minutes":
                 case "hour_of_day_to_run_sanity_checking":
                 case "max_threads": {
@@ -82,6 +86,7 @@ export class Config implements Readonly<MutableConfig> {
                     config[name] = result;
                     break;
                 }
+                // String Config Values
                 case "unprocessed_label":
                 case "processed_label":
                 case "processing_failed_label":
@@ -90,8 +95,13 @@ export class Config implements Readonly<MutableConfig> {
                     config[name] = value;
                     break;
                 }
+                // Boolean Config Values
+                case "parent_labeling": {
+                    config[name] = value.toLowerCase() === 'true';
+                    break;
+                }
                 default: {
-                    console.error(`Invalid config: ${name}`);
+                    throw `Invalid config: "${name}" == "${value}"`;
                 }
             }
         }

--- a/Mocks.ts
+++ b/Mocks.ts
@@ -13,6 +13,7 @@ export default class Mocks {
         processing_failed_label: "zFailed",
         processing_frequency_in_minutes: 5,
         unprocessed_label: "myUnprocessed",
+        parent_labeling: true,
     };
 
     public static getMockConfig = (overrides: Partial<Config> = {}) => (

--- a/Processor.ts
+++ b/Processor.ts
@@ -38,7 +38,7 @@ export class Processor {
                 }
                 if (rule.condition.match(message_data)) {
                     console.log(`rule ${rule} matches message ${message_data}, apply action ${rule.thread_action}`);
-                    thread_data.thread_action.mergeFrom(rule.thread_action);
+                    thread_data.thread_action.mergeFrom(rule.thread_action, session_data.config.parent_labeling);
                     let endThread = false;
                     switch (rule.thread_action.action_after_match) {
                         case ActionAfterMatchType.DONE:
@@ -129,7 +129,8 @@ export class Processor {
             ): ThreadData {
 
             const sheet = Mocks.getMockTestSheet(sheet_rows);
-            const rules = Rule.parseRules(sheet);
+            const config = Mocks.getMockConfig();
+            const rules = Rule.parseRules(sheet, config);
             const session_data = Mocks.getMockSessionData({rules: rules});
             const mock_gmail_thread = Mocks.getMockThreadOfMessages(thread_messages, thread);
             const thread_data = new ThreadData(session_data, mock_gmail_thread);

--- a/Rule.ts
+++ b/Rule.ts
@@ -16,6 +16,7 @@
 
 import Utils from './utils';
 import Condition from "./Condition";
+import {Config} from './Config'
 import Mocks from "./Mocks";
 import ThreadAction, {ActionAfterMatchType, BooleanActionType, InboxActionType} from './ThreadAction';
 
@@ -86,7 +87,7 @@ export class Rule {
         return result;
     }
 
-    public static parseRules(values: string[][]): Rule[] {
+    public static parseRules(values: string[][], config: Config): Rule[] {
         const row_num = values.length;
         const column_num = values[0].length;
 
@@ -130,7 +131,9 @@ export class Rule {
             }
 
             const thread_action = new ThreadAction();
-            thread_action.addLabels(Rule.parseStringList(values[row][header_map["add_labels"]], ","));
+            thread_action.addLabels(
+                Rule.parseStringList(values[row][header_map["add_labels"]], ","),
+                config.parent_labeling);
             thread_action.move_to = Rule.parseInboxActionType(values[row][header_map["move_to"]]);
             thread_action.important = Rule.parseBooleanActionType(values[row][header_map["mark_important"]]);
             thread_action.read = Rule.parseBooleanActionType(values[row][header_map["mark_read"]]);
@@ -148,7 +151,7 @@ export class Rule {
         return rules;
     }
 
-    public static getRules(): Rule[] {
+    public static getRules(config: Config): Rule[] {
         const values: string[][] = Utils.withTimer("GetRuleValues", () => {
             const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('rules');
             if (sheet === null) {
@@ -160,7 +163,7 @@ export class Rule {
                 .getDisplayValues()
                 .map(row => row.map(cell => cell.trim()));
         });
-        const rules = Rule.parseRules(values);
+        const rules = Rule.parseRules(values, config);
         console.log(`Parsed rules:\n${rules.map(rule => rule.toString()).join("\n---\n")}`);
         return rules;
     }
@@ -170,34 +173,39 @@ export class Rule {
             // This can only be tested in the Sheet
 
             it('Reads in default rules from Sheet', () => {
-                const rules = Rule.getRules();
+                const config = Config.getConfig();
+                const rules = Rule.getRules(config);
                 expect(rules.length).toBeGreaterThan(0);
             });
         }
 
         it('Reads in Header', () => {
             const sheet = Mocks.getMockTestSheet([]);
-            const rules = Rule.parseRules(sheet);
+            const config = Mocks.getMockConfig();
+            const rules = Rule.parseRules(sheet, config);
 
             expect(rules.length).toBe(0);
         })
 
         it('Fails with header missing item', () => {
+            const config = Mocks.getMockConfig();
             const sheet = Mocks.getMockTestSheet([]);
             sheet[0] = sheet[0].slice(0, -2);
 
-            expect(() => {Rule.parseRules(sheet)}).toThrow();
+            expect(() => {Rule.parseRules(sheet, config)}).toThrow();
         })
 
         it('Loads Empty Rules', () => {
+            const config = Mocks.getMockConfig();
             const sheet = Mocks.getMockTestSheet([{}, {}]);
 
-            const rules = Rule.parseRules(sheet);
+            const rules = Rule.parseRules(sheet, config);
 
             expect(rules.length).toBe(0);
         })
 
         it('Loads Simple Rule', () => {
+            const config = Mocks.getMockConfig();
             const sheet = Mocks.getMockTestSheet([
                 {
                     conditions: '(body /to: me/i)',
@@ -205,14 +213,50 @@ export class Rule {
                     stage: "5",
                 }]);
 
-            const rules = Rule.parseRules(sheet);
+            const rules = Rule.parseRules(sheet, config);
 
             expect(rules.length).toBe(1);
             expect(rules[0].stage).toBe(5);
             expect(rules[0].thread_action.label_names.size).toBe(2);
         })
 
+        it('Parent Labels Created', () => {
+            const config = Mocks.getMockConfig({parent_labeling: true});
+            const sheet = Mocks.getMockTestSheet([
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc/def, xyz/123',
+                    stage: "5",
+                }]);
+
+            const rules = Rule.parseRules(sheet, config);
+     
+            const expected_labels = new Set(['abc', 'abc/def', 'xyz', 'xyz/123'])
+            expect(rules.length).toBe(1);
+            expect(rules[0].stage).toBe(5);
+            expect(rules[0].thread_action.label_names).toEqual(expected_labels);
+        })
+
+        it('Parent Labels Not Created when configuration disabled', () => {
+            const config = Mocks.getMockConfig({parent_labeling: false});
+            const sheet = Mocks.getMockTestSheet([
+                {
+                    conditions: '(body /to: me/i)',
+                    add_labels: 'abc/def, xyz/123',
+                    stage: "5",
+                }]);
+
+            const rules = Rule.parseRules(sheet, config);
+     
+            const expected_labels = new Set(['abc/def', 'xyz/123'])
+          
+            expect(rules.length).toBe(1);
+            expect(rules[0].stage).toBe(5);
+            expect(rules[0].thread_action.label_names).toEqual(expected_labels);
+        })
+
         it('Loaded Rules are sorted by stage', () => {
+            const config = Mocks.getMockConfig();
             const sheet = Mocks.getMockTestSheet([
                 {
                     conditions: '(body /to: me/i)',
@@ -231,7 +275,7 @@ export class Rule {
                 }
             ]);
 
-            const rules = Rule.parseRules(sheet);
+            const rules = Rule.parseRules(sheet, config);
 
             expect(rules.length).toBe(3);
             expect(rules[0].stage).toBe(1);

--- a/SessionData.ts
+++ b/SessionData.ts
@@ -40,7 +40,7 @@ export class SessionData {
         this.user_email = Utils.withTimer("getEmail", () => Session.getActiveUser().getEmail());
         this.config = Utils.withTimer("getConfigs", () => Config.getConfig());
         this.labels = Utils.withTimer("getLabels", () => SessionData.getLabelMap());
-        this.rules = Utils.withTimer("getRules", () => Rule.getRules());
+        this.rules = Utils.withTimer("getRules", () => Rule.getRules(this.config));
 
         this.processing_start_time = new Date();
         // Check back two processing intervals to make sure we checked all messages in the thread


### PR DESCRIPTION
This adds a config for parent_labeling. By default it is True.

This PR should also include modifying the Sheet's Config page to have the following:


parent_labeling | TRUE
-- | --


Hover-over Note: `Add parent labels to emails. For example if add_labels is 'abc/def', then not only would 'abc/def' be added, but 'abc' (the parent label) would also be added.`

Also config errors now throw an exception so they are noticed by users (Alert box is used by Apps Script).